### PR TITLE
fix(guardarDocumento): ídem directorio para contenido y referencia al documento

### DIFF
--- a/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/SaveDocumentBusinessServiceImpl.java
+++ b/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/SaveDocumentBusinessServiceImpl.java
@@ -282,8 +282,11 @@ public class SaveDocumentBusinessServiceImpl extends DocumentBusinessService
       DocumentEntity documentEntity = new DocumentEntity();
 
       String uuid = UUID.randomUUID().toString();
-      path = DocumentConverter.obtenerRutaFichero(getRutaFicheroCarm(idAplicacion),
-          documentObject.getDir3());
+      path = StringUtils.isNotEmpty(documentObject.getContenidoPorRef())
+          ? documentObject.getContenidoPorRef().substring(0,
+              documentObject.getContenidoPorRef().lastIndexOf(Constants.FILE_SEPARATOR))
+          : DocumentConverter.obtenerRutaFichero(getRutaFicheroCarm(idAplicacion),
+              documentObject.getDir3());
       logger.info("guardamos el documento con uuid: {}", uuid);
 
       documentObject.setPathFile(path);

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
             </directories>
 	    <excludes>
                <exclude>**/*.html</exclude>
+               <exclude>**/*.xml</exclude>
                <exclude>**/*.css</exclude>
             </excludes>
           </configuration>


### PR DESCRIPTION
Parche para que al guardarDocumento (para ENIs) en disco, el fichero contenido (_BF) y el fichero que lo referencia (sin _BF) queden en el mismo directorio.

Closes #25