### PR TITLE
fix(guardarDocumentoENI): closes #27 #28

### DIFF
--- a/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/DocumentBusinessService.java
+++ b/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/DocumentBusinessService.java
@@ -11,6 +11,7 @@
 
 package es.gob.aapp.csvstorage.services.business.document.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,6 +95,19 @@ public class DocumentBusinessService {
   private AuditManagerService auditManagerService;
 
   protected static final Locale locale = LocaleContextHolder.getLocale();
+
+  protected String getRutaFicheroCarm(String idApp) {
+    StringBuilder retVal = new StringBuilder();
+    String app = idApp;
+    if ((null == idApp) || (0 == idApp.trim().length())) {
+      app = "_unknown_";
+    }
+    retVal.append(rutaFichero);
+    retVal.append(File.separator);
+    retVal.append(app.toUpperCase());
+
+    return retVal.toString();
+  }
 
   protected void guardarDocumento(DocumentEntity documentEntity, DocumentObject documentObject,
       UnitEntity unidad, ApplicationEntity applicacion, boolean modificar)

--- a/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/SaveDocumentBusinessServiceImpl.java
+++ b/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/SaveDocumentBusinessServiceImpl.java
@@ -101,19 +101,6 @@ public class SaveDocumentBusinessServiceImpl extends DocumentBusinessService
     return guardarDocumentoUuidResponse;
   }
 
-  private String getRutaFicheroCarm(String idApp) {
-    StringBuilder retVal = new StringBuilder();
-    String app = idApp;
-    if ((null == idApp) || (0 == idApp.trim().length())) {
-      app = "_unknown_";
-    }
-    retVal.append(rutaFichero);
-    retVal.append(File.separator);
-    retVal.append(app.toUpperCase());
-
-    return retVal.toString();
-  }
-
   private List<ApplicationEntity> getRestriccionAplicaciones(DocumentObject documentObject,
       ListaAplicaciones listaAplicaciones, Response response) throws ServiceException {
     List<ApplicationEntity> result = null;

--- a/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/SaveDocumentEniBusinessServiceImpl.java
+++ b/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/business/document/impl/SaveDocumentEniBusinessServiceImpl.java
@@ -138,8 +138,11 @@ public class SaveDocumentEniBusinessServiceImpl extends DocumentBusinessService
       } else {
         DocumentEntity documentEntity = new DocumentEntity();
 
-        String path =
-            DocumentConverter.obtenerRutaFichero(rutaFichero, documentEniObject.getDir3());
+        String path = StringUtils.isNotEmpty(documentEniObject.getContenidoPorRef())
+            ? documentEniObject.getContenidoPorRef().substring(0,
+                documentEniObject.getContenidoPorRef().lastIndexOf(Constants.FILE_SEPARATOR))
+            : DocumentConverter.obtenerRutaFichero(this.getRutaFicheroCarm(idAplicacion),
+                documentEniObject.getDir3());
         String uuid = UUID.randomUUID().toString();
         LOG.debug("Guardamos el documento ENI con el uuid: " + uuid);
 

--- a/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/manager/document/impl/DocumentManagerServiceImpl.java
+++ b/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/services/manager/document/impl/DocumentManagerServiceImpl.java
@@ -285,7 +285,10 @@ public class DocumentManagerServiceImpl implements DocumentManagerService {
 
       name = entity.getUuid() + Constants.BIG_FILE_NAME;
 
-      FileUtil.renameFile(documentObject.getContenidoPorRef(), name);
+      if (!FileUtil.renameFile(documentObject.getContenidoPorRef(), name)) {
+        throw new ServiceException("Se ha producido un error al renombrar el fichero "
+            + documentObject.getContenidoPorRef());
+      }
 
       String refFile = Constants.REF_FILE + documentObject.getPathFile() + separator + name;
       documentInfo.setContenido(refFile.getBytes());
@@ -378,7 +381,10 @@ public class DocumentManagerServiceImpl implements DocumentManagerService {
 
       name = entity.getUuid() + Constants.BIG_FILE_NAME;
 
-      FileUtil.renameFile(documentEniObject.getContenidoPorRef(), name);
+      if (!FileUtil.renameFile(documentEniObject.getContenidoPorRef(), name)) {
+        throw new ServiceException("Se ha producido un error al renombrar el fichero "
+            + documentEniObject.getContenidoPorRef());
+      }
 
       String refFile = Constants.REF_FILE + entity.getRutaFichero() + separator + name;
       documentInfo.setContenido(refFile.getBytes());

--- a/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/util/file/FileUtil.java
+++ b/fuentes/csvstorage/src/main/java/es/gob/aapp/csvstorage/util/file/FileUtil.java
@@ -27,6 +27,7 @@ import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import es.gob.aapp.csvstorage.services.exception.ValidationException;
@@ -282,8 +283,13 @@ public class FileUtil {
 
     File oldfile = new File(path);
     File newfile = new File(oldfile.getParent() + SEPARATOR + newName);
-    correct = oldfile.renameTo(newfile);
-    correct = true;
+    try {
+      FileUtils.moveFile(oldfile, newfile);
+      correct = true;
+    } catch (IOException e) {
+      LOG.warn("No se ha podido renombrar el documento " + path, e);
+    }
+
     LOG.info("renameFile end");
     return correct;
 


### PR DESCRIPTION
Aplicar parche #27 para que al renombrar fichero no se silencien
los fallos que provoquen altas de documentos por MTOM inconsistentes.

Reaplicar parches #3 y #27 a guardarDocumentENI, que no estaba
cubierta.