### PR TITLE
refactor(dependencias): upgrade para corregir CVEs

### DIFF
--- a/fuentes/csvstorage/pom.xml
+++ b/fuentes/csvstorage/pom.xml
@@ -19,47 +19,47 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-orm</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-oxm</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.21</version>
+      <version>1.7.26</version>
     </dependency>
     <!-- Para poder rotar los logs y comprimirlos -->
     <dependency>
@@ -71,23 +71,23 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.7</version>
+      <version>2.6.7.3</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aspects</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
 
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>2.4.7</version>
+      <version>2.4.17</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.woodstox</groupId>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>5.2.4.Final</version>
+      <version>5.3.6.Final</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.thymeleaf.extras</groupId>
       <artifactId>thymeleaf-extras-springsecurity4</artifactId>
-      <version>2.1.2.RELEASE</version>
+      <version>2.1.3.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.0.1.RELEASE</version>
+      <version>4.2.18.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.0.1.RELEASE</version>
+      <version>4.2.18.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -230,7 +230,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -259,7 +259,7 @@
     <dependency>
       <groupId>com.sun.xml.ws</groupId>
       <artifactId>jaxws-rt</artifactId>
-      <version>2.2.10</version>
+      <version>2.3.3</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -277,7 +277,7 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>2.8.0</version>
+      <version>2.12.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -321,7 +321,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -369,7 +369,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-expression</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -404,7 +404,7 @@
     <dependency>
       <groupId>org.springframework.integration</groupId>
       <artifactId>spring-integration-xml</artifactId>
-      <version>4.1.4.RELEASE</version>
+      <version>4.3.23.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -416,7 +416,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-messaging</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -440,7 +440,7 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.14</version>
+      <version>1.22</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -452,7 +452,7 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
-      <version>2.2.1</version>
+      <version>2.3.2</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -464,7 +464,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context-support</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -476,7 +476,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.0.1.RELEASE</version>
+      <version>4.2.18.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/fuentes/csvstorage/src/main/resources/application-context-ws.xml
+++ b/fuentes/csvstorage/src/main/resources/application-context-ws.xml
@@ -11,11 +11,11 @@
    You should have received a copy of the EUPL1.1 license
    along with this program; if not, you may find it at
    http://joinup.ec.europa.eu/software/page/eupl/licence-eupl --> 
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:sec="http://www.springframework.org/schema/security" xmlns:jaxws="http://cxf.apache.org/jaxws" xmlns:context="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-                        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:sec="http://www.springframework.org/schema/security" xmlns:jaxws="http://cxf.apache.org/jaxws" xmlns:context="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd
+                        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
                         http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd
-                        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd"> 
+                        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd"> 
     <context:annotation-config /> 
     <context:component-scan base-package="es.gob.aapp.csvstorage, es.gob.aapp.eeutil.bigDataTransfer" /> 
     <import resource="classpath:META-INF/cxf/cxf.xml" /> 
@@ -38,7 +38,7 @@
     <bean id="applicationUserDetailService" class="es.gob.aapp.csvstorage.services.business.security.ApplicationUserDetailServiceImpl" /> 
     <bean id="ApplicationBusinessService" class="es.gob.aapp.csvstorage.services.business.application.impl.ApplicationBusinessServiceImpl" /> 
     <bean id="customUserTokenValidator" class="es.gob.aapp.csvstorage.webservices.security.wss4j.CustomUserTokenValidator" /> 
-    <sec:authentication-manager alias="authenticationManager"> 
+    <sec:authentication-manager id="authenticationManager"> 
         <sec:authentication-provider user-service-ref="applicationUserDetailService"> 
             <sec:password-encoder hash="sha-256" /> 
         </sec:authentication-provider> 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       </snapshots>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Actualizaciones minor/patch y refactorizaciones necesarias, para corregir los CVEs reportados
por dependabot.

closes #5, closes #7, closes #8, closes #9, closes #41, closes #42, closes #43, closes #44
(también incluye el upgrade de algunas librerías más que no reportaban CVE).

#6 queda pospuesto intencionadamente, por detectar incompatiblidad del upgrade de jackson-databind
con spring-boot-starter-actuator.